### PR TITLE
Rename TemporaryDbContextFactory

### DIFF
--- a/ASP.NET Core/Data/AspNetCoreTemplate.Data/DesignTimeDbContextFactory.cs
+++ b/ASP.NET Core/Data/AspNetCoreTemplate.Data/DesignTimeDbContextFactory.cs
@@ -7,8 +7,7 @@
     using Microsoft.EntityFrameworkCore.Diagnostics;
     using Microsoft.Extensions.Configuration;
 
-    // TODO: Remove. (part of the workaround for https://github.com/aspnet/EntityFramework/issues/5320)
-    public class TemporaryDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
     {
         public ApplicationDbContext CreateDbContext(string[] args)
         {


### PR DESCRIPTION
The implementation of `IDesignTimeDbContextFactory` is needed if migrations are in the web project too.